### PR TITLE
Fix log method if iotdb_log cannot be imported.

### DIFF
--- a/smartthings.py
+++ b/smartthings.py
@@ -32,7 +32,8 @@ try:
     import iotdb_log
 except:
     class iotdb_log(object):
-        def log(self, **ad):
+        @staticmethod
+        def log(**ad):
             pprint.pprint(ad)
 
 class SmartThings(object):


### PR DESCRIPTION
The existing log method was incorrectly defined as an instance method.
