### PR TITLE
Pull user specific API URL from json file api_location property

### DIFF
--- a/smartthings.py
+++ b/smartthings.py
@@ -78,7 +78,7 @@ class SmartThings(object):
     def request_devices(self, device_type):
         """List the devices"""
 
-        devices_url = "https://%s%s/%s" % ( self.std["api_location"], self.endpointd["url"], device_type, )
+        devices_url = "https://%s%s/%s" % ( self.std.get("api_location", "graph.api.smartthings.com"), self.endpointd["url"], device_type, )
         devices_paramd = {
         }
         devices_headerd = {

--- a/smartthings.py
+++ b/smartthings.py
@@ -78,7 +78,7 @@ class SmartThings(object):
     def request_devices(self, device_type):
         """List the devices"""
 
-        devices_url = "https://graph.api.smartthings.com%s/%s" % ( self.endpointd["url"], device_type, )
+        devices_url = "https://%s%s/%s" % ( self.std["api_location"], self.endpointd["url"], device_type, )
         devices_paramd = {
         }
         devices_headerd = {


### PR DESCRIPTION
Allows the user-specific API URL to be stored in the smartthings.json configuration file in the api_location property. Partial workaround for #8 