### PR TITLE
Raise HTTP/JSON/API errors as exceptions

### DIFF
--- a/smartthings.py
+++ b/smartthings.py
@@ -44,15 +44,15 @@ class SmartThings(object):
             raise Exception("HTTP error " + str(response.status_code) + ": " + response.url)
 
     @staticmethod
-    def raise_api_errors(jsonResponse):
-        if "error" in jsonResponse:
-            if type(jsonResponse["error"]) == bool:
-                errorType = jsonResponse.get("type", "Unknown Error")
+    def raise_api_errors(json_response):
+        if "error" in json_response:
+            if type(json_response["error"]) == bool:
+                error_type = json_response.get("type", "Unknown Error")
             else:
-                errorType =  jsonResponse["error"]
-            errorMessage = jsonResponse.get("message", "") + \
-            jsonResponse.get("error_description", "")
-            raise Exception(errorType + ": " + errorMessage)
+                error_type =  json_response["error"]
+            error_message = json_response.get("message", "") + \
+            json_response.get("error_description", "")
+            raise Exception(error_type + ": " + error_message)
 
     def __init__(self, verbose=True):
         self.verbose = verbose

--- a/smartthings.py
+++ b/smartthings.py
@@ -145,7 +145,13 @@ class SmartThings(object):
             headers=command_headerd,
             data=json.dumps(requestd)
         )
-        SmartThings.raise_request_errors(command_response)
+
+        command_api_response = {}
+        try:
+            command_api_response = command_response.json()
+        except ValueError:
+            SmartThings.raise_request_errors(command_response)
+        SmartThings.raise_api_errors(command_api_response)
 
     def device_types(self):
         return dtypes

--- a/smartthings.py
+++ b/smartthings.py
@@ -83,11 +83,13 @@ class SmartThings(object):
         }
 
         endpoints_response = requests.get(url=endpoints_url, params=endpoints_paramd)
+        
         try:
             endpoints = endpoints_response.json()
         except ValueError:
             SmartThings.raise_request_errors(endpoints_response)
             raise Exception("Received invalid JSON response")
+
         SmartThings.raise_api_errors(endpoints)
         self.endpointd = endpoints[0]
         if self.verbose: iotdb_log.log(
@@ -108,12 +110,14 @@ class SmartThings(object):
         }
 
         devices_response = requests.get(url=devices_url, params=devices_paramd, headers=devices_headerd)
+        
         try:
             self.deviceds = devices_response.json()
         except ValueError:
             SmartThings.raise_request_errors(devices_response)
             raise Exception("Received invalid JSON response")
         SmartThings.raise_api_errors(self.deviceds)
+
         for switchd in self.deviceds:
             switchd['url'] = "%s/%s" % ( devices_url, switchd['id'], )
 
@@ -141,6 +145,7 @@ class SmartThings(object):
             headers=command_headerd,
             data=json.dumps(requestd)
         )
+        SmartThings.raise_request_errors(command_response)
 
     def device_types(self):
         return dtypes

--- a/smartthings.py
+++ b/smartthings.py
@@ -37,6 +37,23 @@ except:
             pprint.pprint(ad)
 
 class SmartThings(object):
+
+    @staticmethod
+    def raise_request_errors(response):
+        if not response.ok:
+            raise Exception("HTTP error " + str(response.status_code) + ": " + response.url)
+
+    @staticmethod
+    def raise_api_errors(jsonResponse):
+        if "error" in jsonResponse:
+            if type(jsonResponse["error"]) == bool:
+                errorType = jsonResponse.get("type", "Unknown Error")
+            else:
+                errorType =  jsonResponse["error"]
+            errorMessage = jsonResponse.get("message", "") + \
+            jsonResponse.get("error_description", "")
+            raise Exception(errorType + ": " + errorMessage)
+
     def __init__(self, verbose=True):
         self.verbose = verbose
         self.std = {}
@@ -66,8 +83,13 @@ class SmartThings(object):
         }
 
         endpoints_response = requests.get(url=endpoints_url, params=endpoints_paramd)
-        self.endpointd = endpoints_response.json()[0]
-
+        try:
+            endpoints = endpoints_response.json()
+        except ValueError:
+            SmartThings.raise_request_errors(endpoints_response)
+            raise Exception("Received invalid JSON response")
+        SmartThings.raise_api_errors(endpoints)
+        self.endpointd = endpoints[0]
         if self.verbose: iotdb_log.log(
             "endpoints",
             endpoints_url=endpoints_url,
@@ -86,7 +108,12 @@ class SmartThings(object):
         }
 
         devices_response = requests.get(url=devices_url, params=devices_paramd, headers=devices_headerd)
-        self.deviceds = devices_response.json()
+        try:
+            self.deviceds = devices_response.json()
+        except ValueError:
+            SmartThings.raise_request_errors(devices_response)
+            raise Exception("Received invalid JSON response")
+        SmartThings.raise_api_errors(self.deviceds)
         for switchd in self.deviceds:
             switchd['url'] = "%s/%s" % ( devices_url, switchd['id'], )
 


### PR DESCRIPTION
# Raise errors as exceptions
Type: Feature
Description: Raise HTTP/JSON/API errors as exceptions in order to make it more obvious what is going wrong. Related to #8 

## Implemented for methods:

- request_devices 
- request_endpoints
- device_request

## Handles:

- HTTP Status code errors
- Invalid JSON responses
- API errors received in JSON

## Methodology:

1. Check if JSON can be decoded. If not:
   - Check for HTTP status code errors
   - Otherwise raise generic invalid JSON error (except for device_request, as blank response indicates success)
2. Check for API error in JSON response
   - JSON Errors come in two flavors, so method handles both types

## Appendix:
API Error formats observed / handled:
1. {"error":true,"type":"{type}","message":"{message}"}
2. {"error":"{type}","error_description":"{message}"}